### PR TITLE
Add initial logic for pit bat spawn placement

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -17,6 +17,21 @@ function bestiaryMod:onUpdate()
   end     
 end
 
+-- Helper function, taken from https://stackoverflow.com/questions/1410862/concatenation-of-tables-in-lua
+function array_concat(...) 
+    local t = {}
+    for n = 1,select("#",...) do
+        local arg = select(n,...)
+        if type(arg)=="table" then
+            for _,v in ipairs(arg) do
+                t[#t+1] = v
+            end
+        else
+            t[#t+1] = arg
+        end
+    end
+    return t
+end
 
 local function getEntity(name, subt)
     if subt == nil then
@@ -391,6 +406,8 @@ RedPuppetCollectible:AddCallback(ModCallbacks.MC_FAMILIAR_UPDATE, RedPuppetColle
 RedPuppetCollectible:AddCallback(ModCallbacks.MC_FAMILIAR_INIT, RedPuppetCollectible.onFamiliarInit, RedPuppetCollectible.VARIANT_REDPUPPET);
 local pitBatMod = RegisterMod("Bestiary - Pit Bat", 1)
 
+local MAX_BAT_COUNT_PER_ROOM = 2
+
 function pitBatMod:newGame(fromSave)
     if not fromSave then
         rng:SetSeed(game:GetSeeds():GetStartSeed(), 0)
@@ -438,21 +455,120 @@ end
 
 pitBatMod:AddCallback(ModCallbacks.MC_NPC_UPDATE, pitBatMod.pitBatControl, Entities.PIT_BAT.id)
 
+function pitBatMod:cellToIndex(gridWidth, cellX, cellY)
+	return cellY * gridWidth + cellX
+end
+
+function pitBatMod:getGridEntityAtCell(room, cellX, cellY)
+	return room:GetGridEntity(pitBatMod:cellToIndex(room:GetGridWidth(), cellX, cellY))
+end
+
+function pitBatMod:generatePitTable()
+		local room = game:GetLevel():GetCurrentRoom()
+		local pitTable = {}
+
+		for col = 1, room:GetGridWidth() do
+			pitTable[col] = {}
+
+			for row = 1, room:GetGridHeight() do
+				gridEntity = pitBatMod:getGridEntityAtCell(room, col - 1, row - 1)
+
+				if gridEntity then
+					pitTable[col][row] = not not gridEntity:ToPit()  -- boolean logic with nil is funny, I think this is an okay way of doing this.
+				else
+					pitTable[col][row] = false
+				end
+            end
+		end
+
+		return pitTable
+end
+
+function pitBatMod:extractPitEdgeCellsHelper(pitTable, visitedTable, cellX, cellY, width, height, indices)
+	isPit = pitTable[cellX][cellY]
+
+	if visitedTable[cellX][cellY] or not isPit then
+		return isPit and 0 or 1 --  Return 0 if pit, 1 if not.
+	end
+
+	visitedTable[cellX][cellY] = true
+	numberOfNonPitNeighbors = 0
+
+    function clamp(x, y)
+        if not ((1 <= x) and (x <= width)) then
+            x = (x < 1) and 1 or width
+        end
+
+        if not ((1 <= y) and (y <= height)) then
+            y = (y < 1) and 1 or height
+        end
+
+        return x, y
+    end
+
+    for xOffset = -1, 1 do
+		for yOffset = -1, 1 do
+			if (xOffset ~= 0) or (yOffset ~= 0) then
+				x, y = clamp(cellX + xOffset, cellY + yOffset)
+
+				numberOfNonPitNeighbors = numberOfNonPitNeighbors + pitBatMod:extractPitEdgeCellsHelper(
+						pitTable, visitedTable, x, y, width, height, indices)			
+			end
+		end	
+	end
+
+	if numberOfNonPitNeighbors > 0 then
+		table.insert(indices, pitBatMod:cellToIndex(width, cellX - 1, cellY - 1))
+	end
+
+	return isPit and 0 or 1
+end
+
+-- Returns an "array" of grid indices containing pit edge cells.
+function pitBatMod:extractPitEdgeCells(pitTable)
+	width = #pitTable
+	height = #pitTable[1]
+
+	indices = {}
+	visitedTable = {}  -- First need to populate this with false, as we have not visited any cells.
+
+	for i = 1, width do
+		visitedTable[i] = {}
+
+		for j = 1, height do
+			visitedTable[i][j] = false
+		end
+	end
+	
+	for col = 1, width do
+		for row = 1, height do
+			if pitTable[col][row] and not visitedTable[col][row] then
+				pitBatMod:extractPitEdgeCellsHelper(pitTable, visitedTable,
+						col, row, width, height, indices)
+			end
+		end
+	end
+	
+	return indices
+end
+
 function pitBatMod:populatePits()
     local room = game:GetLevel():GetCurrentRoom()
     local spawnCount = 0
-    
+
     if not room:IsClear() then
-        for i = 0, room:GetGridSize() do
-            if spawnCount >= 2 then
+		pitEdgeCells = pitBatMod:extractPitEdgeCells(pitBatMod:generatePitTable())
+
+        for i = 1, #pitEdgeCells do
+            if spawnCount >= MAX_BAT_COUNT_PER_ROOM then
                 break
             end
             
-            if room:GetGridEntity(i) and rng:RandomInt(30) == 1 then
-                if room:GetGridEntity(i):ToPit() then
-                    spawnCount = spawnCount + 1
-                    Isaac.Spawn(Entities.PIT_BAT.id, Entities.PIT_BAT.variant, 0, room:GetGridPosition(i), Vector(0, 0), nil)
-                end
+            if rng:RandomInt(30) == 1 then --  30 is some magic number.  Dunno.
+				spawnCount = spawnCount + 1
+
+				Isaac.Spawn(Entities.PIT_BAT.id, Entities.PIT_BAT.variant, 0,
+						room:GetGridPosition(pitEdgeCells[i]), Vector(0, 0), nil)
             end
         end
     end

--- a/src/enemies/pitbat.lua
+++ b/src/enemies/pitbat.lua
@@ -47,6 +47,72 @@ end
 
 pitBatMod:AddCallback(ModCallbacks.MC_NPC_UPDATE, pitBatMod.pitBatControl, Entities.PIT_BAT.id)
 
+function pitBatMod:cellToIndex(gridWidth, cellX, cellY)
+	return cellY * gridWidth + cellX
+end
+
+function pitBatMod:getGridEntityAtCell(room, cellX, cellY)
+	return room:getGridEntity(pitBatMod.cellToIndex(room:GetGridWidth(), cellX, cellY))
+end
+
+function pitBatMod:generatePitTable()
+		local room = game:GetLevel():GetCurrentRoom()
+		local gridSize = room:GetGridSize()
+		local roomWidth = room:GetGridWidth()
+		local roomHeight = room:GetGridHeight()
+
+		local pitTable = {}
+		
+		for col = 1, roomWidth do
+			pitTable[col] = {}
+			
+			for row = 1, roomHeight do
+				entity = getGridEntityAtCell(room, col - 1, row - 1)
+
+				pitTable[col][row] = not not entity:ToPit()  -- boolean logic with nil is funny, I think this is an okay way of doing this.
+            end
+		end
+		
+		return pitTable
+end
+
+function pitBatMod:extractPitEdgeCellsHelper(pitTable, visitedTable, cellX, cellY, width, height)
+	indices = {}
+	visitedTable[cellX][cellY] = true
+	
+	
+end
+
+-- Returns an "array" of grid indices containing pit edge cells.
+function pitBatMod:extractPitEdgeCells(pitTable)
+	width = #pitTable
+	height = #pitTable[1]
+
+	visitedTable = {}  -- First need to populate this with false, as we have not visited any cells.
+	indices = {}
+	
+	for i = 1, width do
+		visitedTable[i] = {}
+		
+		for j = 1, height do
+			visitedTable[i][j] = false
+		end
+	end
+	
+	for col = 1, width do
+		for row = 1, height do
+			if not visited[col][row] then
+				newIndices = pitBatMod.extractPitEdgeCellsHelper(pitTable, visitedTable,
+						col, row, width, height)
+						
+				indices = array_concat(indices, newIndices)
+			end
+			
+	return indices
+end
+
+--extractPitEdgeCells({}, 5, 4, cellX, cellY, {})
+
 function pitBatMod:populatePits()
     local room = game:GetLevel():GetCurrentRoom()
     local spawnCount = 0

--- a/src/enemies/pitbat.lua
+++ b/src/enemies/pitbat.lua
@@ -80,7 +80,7 @@ function pitBatMod:extractPitEdgeCellsHelper(pitTable, visitedTable, cellX, cell
 	indices = {}
 	visitedTable[cellX][cellY] = true
 	
-	
+	leftIndices = pitBatMod.extractPitEdgeCellsHelper(pitTable, visitedTable
 end
 
 -- Returns an "array" of grid indices containing pit edge cells.

--- a/src/globals.lua
+++ b/src/globals.lua
@@ -17,6 +17,21 @@ function bestiaryMod:onUpdate()
   end     
 end
 
+-- Helper function, taken from https://stackoverflow.com/questions/1410862/concatenation-of-tables-in-lua
+function array_concat(...) 
+    local t = {}
+    for n = 1,select("#",...) do
+        local arg = select(n,...)
+        if type(arg)=="table" then
+            for _,v in ipairs(arg) do
+                t[#t+1] = v
+            end
+        else
+            t[#t+1] = arg
+        end
+    end
+    return t
+end
 
 local function getEntity(name, subt)
     if subt == nil then


### PR DESCRIPTION
Add functions to do the following:

- Find pits in a room
- Find which pit cells are adjacent to non-pit cells (i.e. edges of
pits)
- Add constant MAX_BAT_COUNT_PER_ROOM to limit number of bats that can
be spawned
- Code to spawn bats

Issues:

- Bats spawning at the top of "columns" of pit cells look bad.
- Bats spawning in pit cells against walls that are too far away to
trigger.